### PR TITLE
[MOSIP-44044] : Removed download card feature in admin portal

### DIFF
--- a/admin-ui/src/app/app.constants.ts
+++ b/admin-ui/src/app/app.constants.ts
@@ -76,14 +76,14 @@ export const navItems = [
     auditEventId: 'ADM-008',
     roles: ['REGISTRATION_ADMIN']
   },
-  {
-    displayName: 'menuItems.item9.title',
-    icon: './assets/images/packet-status.svg',
-    route: '/admin/download-card',
-    children: null,
-    auditEventId: 'ADM-009',
-    roles: ['DIGITALCARD_ADMIN']
-  },
+  // {
+  //   displayName: 'menuItems.item9.title',
+  //   icon: './assets/images/packet-status.svg',
+  //   route: '/admin/download-card',
+  //   children: null,
+  //   auditEventId: 'ADM-009',
+  //   roles: ['DIGITALCARD_ADMIN']
+  // },
   {
     displayName: 'menuItems.item5.title',
     icon: './assets/images/id-card.svg',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed the download card navigation item from the admin menu, streamlining navigation options and reducing available admin routes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->